### PR TITLE
Add pa12 link into preassignments.qmd

### DIFF
--- a/preassignments.qmd
+++ b/preassignments.qmd
@@ -227,7 +227,7 @@ pa <-  DATES |> filter(element == "Pre-Assignments", item == 12)
   - Released to Students: `{r} pa |> filter(str_detect(Details, "Pre-Assignment Released")) |> pull(dt)`
   - **Due on Brightspace: `{r} pa |> filter(str_detect(Details, "Pre-Assignment Due")) |> pull(dt)`**
 
-TBA
+In [this week's preassignment](./preassigns/pa12.html), we explore the world of text data.
 
 #### Pre-Assignment for Week #13 - `{r} get_pa_title(13)`
 


### PR DESCRIPTION
Hi professor,

I added the preassignment 12 link into the .qmd file. Also, not sure if there is a pa13 or not. I check the pa13.qmd, which doesn't seem to have content inside.